### PR TITLE
Fix empty json string issue

### DIFF
--- a/src/zjson2abaptype.prog.abap
+++ b/src/zjson2abaptype.prog.abap
@@ -152,6 +152,11 @@ CLASS lcl_hlp IMPLEMENTATION.
         OTHERS                 = 3
     ).
     IF sy-subrc EQ 0.
+    
+      IF source is initial.
+        MESSAGE s001(00) WITH 'Data input is required' DISPLAY LIKE 'E' ##MG_MISSING ##NO_TEXT.
+        RETURN.
+      ENDIF.
 
       DATA(json_data) = /ui2/cl_json=>generate( json = cl_bcs_convert=>txt_to_string( it_soli   = source ) pretty_name = pretty_name_mode ).
       IF json_data IS INITIAL.


### PR DESCRIPTION
Try to convert a empty string will cause the 'STRING_OFFSET_TOO_LARGE' rumtime error.
Add check to aviod this dump.
![image](https://user-images.githubusercontent.com/16676760/66533119-5ea9ca80-eb44-11e9-8e73-cb79b1775510.png)
![image](https://user-images.githubusercontent.com/16676760/66533133-6b2e2300-eb44-11e9-87c9-abacf2613b00.png)
