### PR TITLE
fix issue for type p

### DIFF
--- a/src/zjson2abaptype.prog.abap
+++ b/src/zjson2abaptype.prog.abap
@@ -434,7 +434,7 @@ CLASS lcl_json_structure IMPLEMENTATION.
     IF c_type-type EQ cl_abap_typedescr=>typekind_char.
       c_type-final_type = |{ c_type-name } type { c_type-absolute_type } length { c_type-length }|.
     ELSEIF c_type-type EQ cl_abap_typedescr=>typekind_packed.
-      c_type-final_type = |{ c_type-name } type { c_type-absolute_type } length { c_type-length } decimals { c_type-decimals }|.
+      c_type-final_type = |{ c_type-name } type { c_type-type } length { c_type-length } decimals { c_type-decimals }|.
     ELSEIF c_type-type EQ cl_abap_typedescr=>typekind_num.
       c_type-final_type = |{ c_type-name } type { c_type-absolute_type } length { c_type-length }|.
     ELSE.

--- a/src/zui2_json.clas.abap
+++ b/src/zui2_json.clas.abap
@@ -918,7 +918,7 @@ METHOD generate_int.
         IF json+offset CS '.'.
           CREATE DATA rr_data TYPE f.
         ELSEIF length GT 9.
-          CREATE DATA rr_data TYPE p.
+          CREATE DATA rr_data TYPE p LENGTH 16.
         ELSE.
           CREATE DATA rr_data TYPE i.
         ENDIF.


### PR DESCRIPTION
I got a feedback about the subtle bug. For the numeric variable which has a length greater than 9, the type result always be "**TYPE %_t00006s00000000o0000000157 LENGTH 8 DECIMALS 0**". It is incorrect.
![image](https://user-images.githubusercontent.com/16676760/68106778-a5a99680-ff1d-11e9-813e-bb39ba0a6693.png)

There are 2 changes for the issue.
1) For type p, use "type" field as the final type instead of "absolute type".
2) In the /UI2/CL_JSON (now is ZUI2_JSON), SAP declares "type p" for the numeric variable whose length GT 9. So it has a default length 8, which is not enough for some long numbers. Set the length as 16 to avoid potential OVERFLOW.